### PR TITLE
zig: use std.heap.page_allocator to keep the benchmark numbers more fair

### DIFF
--- a/fannkuch-redux/zig/main.zig
+++ b/fannkuch-redux/zig/main.zig
@@ -2,6 +2,9 @@ const std = @import("std");
 const stdout = std.io.getStdOut().writer();
 const stderr = std.io.getStdErr().writer();
 
+var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+const allocator = gpa.allocator();
+
 const Fannkuchen = struct {
     s: [16]i64,
     t: [16]i64,
@@ -72,10 +75,8 @@ const Fannkuchen = struct {
 };
 
 pub fn main() !void {
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-    const args = try std.process.argsAlloc(arena.allocator());
-    defer std.process.argsFree(arena.allocator(), args);
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
 
     if (args.len < 2) {
         try stderr.print("Usage: {s} <n>\n", .{args[0]});

--- a/n-body-nosqrt/zig/main.zig
+++ b/n-body-nosqrt/zig/main.zig
@@ -2,6 +2,9 @@ const std = @import("std");
 const math = std.math;
 const stdout = std.io.getStdOut().writer();
 
+var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+const allocator = gpa.allocator();
+
 const pi = 3.141592653589793;
 const solarMass = 4 * pi * pi;
 const daysPerYear = 365.24;
@@ -146,9 +149,7 @@ var Bodies = [_]Planet{
 };
 
 pub fn main() !void {
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-    const args = try std.process.argsAlloc(arena.allocator());
+    const args = try std.process.argsAlloc(allocator);
 
     if (args.len < 2) {
         std.debug.print("Usage: {s} <iterations>\n", .{args[0]});

--- a/n-body/zig/main.zig
+++ b/n-body/zig/main.zig
@@ -2,6 +2,9 @@ const std = @import("std");
 const math = std.math;
 const stdout = std.io.getStdOut().writer();
 
+var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+const allocator = gpa.allocator();
+
 const pi = 3.141592653589793;
 const solarMass = 4 * pi * pi;
 const daysPerYear = 365.24;
@@ -129,9 +132,7 @@ var Bodies = [_]Planet{
 };
 
 pub fn main() !void {
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-    const args = try std.process.argsAlloc(arena.allocator());
+    const args = try std.process.argsAlloc(allocator);
 
     if (args.len < 2) {
         std.debug.print("Usage: {s} <iterations>\n", .{args[0]});


### PR DESCRIPTION
This PR changes the zig benchmark programs to use `std.heap.page_allocator` instead of the `ArenaAllocator` to keep the benchmark numbers more fair.