### PR TITLE
fix Rust fannkuch redux performance

### DIFF
--- a/fannkuch-redux/rust/main.rs
+++ b/fannkuch-redux/rust/main.rs
@@ -95,21 +95,26 @@ impl Pfannkuch {
 }
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        eprintln!(
-            "usage: {} number",
-            args.get(0).map_or("fannkuch_redux_rust", |s| s.as_str())
-        );
-        process::exit(1);
-    }
+    let mut args = env::args();
+
+    let prog_name = args.next();
+
+    let num_str = match args.next() {
+        Some(number_str) => number_str,
+        None => {
+            // no number argument
+            let name = prog_name.unwrap_or("fannkuch_redux_rust".to_string());
+            eprintln!("usage: {name} number");
+            process::exit(1);
+        }
+    };
 
     let mut pf = Pfannkuch::default(); // zero initialize by default
 
-    match args[1].parse::<u32>() {
+    match num_str.parse::<u32>() {
         Ok(n) => pf.max_n = n,
         Err(_) => {
-            eprintln!("Error: '{}' is not a valid number.", args[1]);
+            eprintln!("Error: '{num_str}' is not a valid number.");
             process::exit(1);
         }
     }

--- a/fannkuch-redux/rust/main.rs
+++ b/fannkuch-redux/rust/main.rs
@@ -27,7 +27,7 @@ impl Pfannkuch {
 
     fn flip(&mut self) -> i32 {
         let mut flips_count = 1;
-        
+
         let current_max_n = self.max_n as usize;
         self.t[..current_max_n].copy_from_slice(&self.s[..current_max_n]);
 
@@ -41,7 +41,7 @@ impl Pfannkuch {
                 y -= 1;
             }
             flips_count += 1;
-            
+
             if self.t[self.t[0] as usize] == 0 {
                 break;
             }
@@ -62,10 +62,10 @@ impl Pfannkuch {
     fn tk(&mut self, n_param: i32) {
         let mut p_count = 0; // Permutation counter index, Go's 'i' in tk
         let mut c_perm_counts = [0 as Elem; 16]; // Permutation counts, Go's 'c' in tk
-        
+
         while p_count < n_param {
-            self.rotate(p_count); 
-            
+            self.rotate(p_count);
+
             let p_count_usize = p_count as usize;
 
             if c_perm_counts[p_count_usize] >= p_count as Elem {
@@ -75,13 +75,13 @@ impl Pfannkuch {
             }
 
             c_perm_counts[p_count_usize] += 1;
-            p_count = 1; 
-            
-            self.odd = !self.odd; 
+            p_count = 1;
+
+            self.odd = !self.odd;
 
             if self.s[0] != 0 {
                 let mut f = 1;
-                if self.s[self.s[0] as usize] != 0 { 
+                if self.s[self.s[0] as usize] != 0 {
                     f = self.flip();
                 }
 
@@ -89,9 +89,11 @@ impl Pfannkuch {
                     self.maxflips = f;
                 }
 
-                if self.odd != 0 { // If odd is -1
+                if self.odd != 0 {
+                    // If odd is -1
                     self.checksum -= f;
-                } else { // If odd is 0
+                } else {
+                    // If odd is 0
                     self.checksum += f;
                 }
             }
@@ -102,12 +104,15 @@ impl Pfannkuch {
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        eprintln!("usage: {} number", args.get(0).map_or("fannkuch_redux_rust", |s| s.as_str()));
+        eprintln!(
+            "usage: {} number",
+            args.get(0).map_or("fannkuch_redux_rust", |s| s.as_str())
+        );
         process::exit(1);
     }
 
     let mut pf = Pfannkuch::new();
-    
+
     match args[1].parse::<i32>() {
         Ok(n) => pf.max_n = n,
         Err(_) => {
@@ -127,5 +132,8 @@ fn main() {
 
     pf.tk(pf.max_n);
 
-    println!("{}\nPfannkuchen({}) = {}", pf.checksum, pf.max_n, pf.maxflips);
+    println!(
+        "{}\nPfannkuchen({}) = {}",
+        pf.checksum, pf.max_n, pf.maxflips
+    );
 }

--- a/fannkuch-redux/rust/main.rs
+++ b/fannkuch-redux/rust/main.rs
@@ -1,35 +1,25 @@
 use std::env;
 use std::process;
 
-type Elem = i32;
+type Elem = u32;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct Pfannkuch {
     s: [Elem; 16],
     t: [Elem; 16],
-    maxflips: i32,
-    max_n: i32,
-    odd: i32,
+    maxflips: u32,
+    max_n: u32,
+    odd: u32,
     checksum: i32,
 }
 
 impl Pfannkuch {
-    fn new() -> Self {
-        Pfannkuch {
-            s: [0; 16],
-            t: [0; 16],
-            maxflips: 0,
-            max_n: 0,
-            odd: 0, // Initialized to 0
-            checksum: 0,
+    fn flip(&mut self, n_param: u32) -> u32 {
+        for i in 0..(n_param as usize) {
+            self.t[i] = self.s[i];
         }
-    }
 
-    fn flip(&mut self) -> i32 {
         let mut flips_count = 1;
-
-        let current_max_n = self.max_n as usize;
-        self.t[..current_max_n].copy_from_slice(&self.s[..current_max_n]);
 
         loop {
             let mut x: usize = 0;
@@ -40,16 +30,18 @@ impl Pfannkuch {
                 x += 1;
                 y -= 1;
             }
+
             flips_count += 1;
 
             if self.t[self.t[0] as usize] == 0 {
                 break;
             }
         }
+
         flips_count
     }
 
-    fn rotate(&mut self, n: i32) {
+    fn rotate(&mut self, n: u32) {
         let c = self.s[0];
         let n_usize = n as usize;
         for i in 0..n_usize {
@@ -59,7 +51,7 @@ impl Pfannkuch {
     }
 
     // n_param is self.max_n from main, which is the N for Fannkuch.
-    fn tk(&mut self, n_param: i32) {
+    fn tk(&mut self, n_param: u32) {
         let mut p_count = 0; // Permutation counter index, Go's 'i' in tk
         let mut c_perm_counts = [0 as Elem; 16]; // Permutation counts, Go's 'c' in tk
 
@@ -76,13 +68,14 @@ impl Pfannkuch {
 
             c_perm_counts[p_count_usize] += 1;
             p_count = 1;
-
             self.odd = !self.odd;
 
-            if self.s[0] != 0 {
+            let idx = self.s[0] as usize;
+            if idx != 0 {
                 let mut f = 1;
-                if self.s[self.s[0] as usize] != 0 {
-                    f = self.flip();
+
+                if self.s[idx] != 0 {
+                    f = self.flip(n_param);
                 }
 
                 if f > self.maxflips {
@@ -90,11 +83,11 @@ impl Pfannkuch {
                 }
 
                 if self.odd != 0 {
-                    // If odd is -1
-                    self.checksum -= f;
+                    // not odd
+                    self.checksum -= f as i32;
                 } else {
-                    // If odd is 0
-                    self.checksum += f;
+                    // odd
+                    self.checksum += f as i32;
                 }
             }
         }
@@ -111,9 +104,9 @@ fn main() {
         process::exit(1);
     }
 
-    let mut pf = Pfannkuch::new();
+    let mut pf = Pfannkuch::default(); // zero initialize by default
 
-    match args[1].parse::<i32>() {
+    match args[1].parse::<u32>() {
         Ok(n) => pf.max_n = n,
         Err(_) => {
             eprintln!("Error: '{}' is not a valid number.", args[1]);


### PR DESCRIPTION
I saw some oddities in the graphs comparing the performances between Rust and C, so I decided to fix it at least a little. The main problems seemed to be lots of i32 to usize conversions, Rust wasnt too happy about those and it also doesn't make sense to keep non-decrementing integers as i32, since they cannot be negative. 

Another one was having `self.t[..current_max_n].copy_from_slice(&self.s[..current_max_n]);` in a hot loop with tiny ranges, having a simple for loop is just faster and actually closer to the other implementations

I also removed the allocation for the input args, since they don't need to be allocated and they aren't allocated in the C implementation

I got around ~20% performance improvement with just these simple changes

I also noticed that you are doing printing in the benchmarks, this is pretty bad for quick programs, for example in rust fannkuch-redux with input of `6`, the actual calculation takes ~25µs but printing takes 530µs, so 95% of the benchmark time is just the printing. This seems pretty inaccurate when it comes to comparing languages, you are essentially just comparing printing functions of each

I didn't do anything to the print function, but you really should run the benchmarks in a way where they do not contain any printing or such

also I saw that you are running the benchmarks with `-O2` optimizations but you are running Zig with `-OReleaseSafe`, these are most certainly not 1 to 1 comparable, the Zig's release safe is more like `-O3` + bounds checks, so all the benchmarks are just twitsted into Zigs favor. Rust having bounds checks on normal release means that `-O3` for Rust is much more comparable to `-OReleaseSafe`

I would honestly just run everyone of them with `-O3` / `release` but have additional benchmark for Zig for `-OReleaseSafe`, this would be much more accurate to the real life performance than `-O2`