### PR TITLE
Better benchmark fairness

### DIFF
--- a/compilerflags_test.go
+++ b/compilerflags_test.go
@@ -36,6 +36,6 @@ var tinygoBaseFlags = []string{
 }
 
 var rustBaseFlags = []string{
-	"-Copt-level=2",
+	"-Copt-level=3",
 	"-o", "rust.bin",
 }

--- a/fannkuch-redux/c/main.c
+++ b/fannkuch-redux/c/main.c
@@ -8,6 +8,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <string.h>
+
 
 /* this depends highly on the platform.  It might be faster to use
    char type on 32-bit systems; it might be faster to use unsigned. */
@@ -73,25 +75,26 @@ void tk(pfannkuch* pf)
    }
 }
 
-int main(int argc, char **v)
+int main(int argc, char **argv)
 {
    int i;
 
    if (argc < 2) {
-      fprintf(stderr, "usage: %s number\n", v[0]);
+      fprintf(stderr, "usage: %s number\n", argv[0]);
       exit(1);
    }
    pfannkuch pf = {};
-   pf.max_n = atoi(v[1]);
-   if ( pf.max_n < 3 || pf.max_n > 15) {
+   pf.max_n = atoi(argv[1]);
+   int verify = argc > 2 && strcmp(argv[2], "v") == 0;
+   if (pf.max_n < 3 || pf.max_n > 15) {
       fprintf(stderr, "range: must be 3 <= n <= 12\n");
       exit(1);
    }
 
    for (i = 0; i < pf.max_n; i++) pf.s[i] = i;
    tk(&pf);
-
-   printf("%d\nPfannkuchen(%d) = %d\n", pf.checksum, pf.max_n, pf.maxflips);
-
+   if (verify) {
+      printf("%d\nPfannkuchen(%d) = %d\n", pf.checksum, pf.max_n, pf.maxflips);
+   }
    return 0;
 }

--- a/fannkuch-redux/go/main.go
+++ b/fannkuch-redux/go/main.go
@@ -7,10 +7,10 @@ import (
 )
 
 type pfannkuch struct {
-	s, t	 [16]elem
+	s, t     [16]elem
 	maxflips int
-	max_n	int
-	odd	  int
+	max_n    int
+	odd      int
 	checksum int
 }
 

--- a/fannkuch-redux/go/main.go
+++ b/fannkuch-redux/go/main.go
@@ -7,10 +7,10 @@ import (
 )
 
 type pfannkuch struct {
-	s, t     [16]elem
+	s, t	 [16]elem
 	maxflips int
-	max_n    int
-	odd      int
+	max_n	int
+	odd	  int
 	checksum int
 }
 
@@ -80,15 +80,16 @@ func main() {
 	}
 	var pf pfannkuch
 	pf.max_n, _ = strconv.Atoi(os.Args[1])
+	verify := len(os.Args) > 2 && os.Args[2] == "v"
 	if pf.max_n < 3 || pf.max_n > 15 {
 		fmt.Fprintf(os.Stderr, "max N range: must be 3 <= n <= 12\n")
 		os.Exit(1)
 	}
-
 	for i := 0; i < pf.max_n; i++ {
 		pf.s[i] = elem(i)
 	}
 	pf.tk(pf.max_n)
-
-	fmt.Printf("%d\nPfannkuchen(%d) = %d\n", pf.checksum, pf.max_n, pf.maxflips)
+	if verify {
+		fmt.Printf("%d\nPfannkuchen(%d) = %d\n", pf.checksum, pf.max_n, pf.maxflips)
+	}
 }

--- a/fannkuch-redux/rust/main.rs
+++ b/fannkuch-redux/rust/main.rs
@@ -95,21 +95,26 @@ impl Pfannkuch {
 }
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        eprintln!(
-            "usage: {} number",
-            args.get(0).map_or("fannkuch_redux_rust", |s| s.as_str())
-        );
-        process::exit(1);
-    }
+    let mut args = env::args();
+
+    let prog_name = args.next();
+
+    let num_str = match args.next() {
+        Some(number_str) => number_str,
+        None => {
+            // no number argument
+            let name = prog_name.unwrap_or("fannkuch_redux_rust".to_string());
+            eprintln!("usage: {name} number");
+            process::exit(1);
+        }
+    };
 
     let mut pf = Pfannkuch::default(); // zero initialize by default
 
-    match args[1].parse::<u32>() {
+    match num_str.parse::<u32>() {
         Ok(n) => pf.max_n = n,
         Err(_) => {
-            eprintln!("Error: '{}' is not a valid number.", args[1]);
+            eprintln!("Error: '{num_str}' is not a valid number.");
             process::exit(1);
         }
     }

--- a/fannkuch-redux/rust/main.rs
+++ b/fannkuch-redux/rust/main.rs
@@ -27,7 +27,7 @@ impl Pfannkuch {
 
     fn flip(&mut self) -> i32 {
         let mut flips_count = 1;
-        
+
         let current_max_n = self.max_n as usize;
         self.t[..current_max_n].copy_from_slice(&self.s[..current_max_n]);
 
@@ -41,7 +41,7 @@ impl Pfannkuch {
                 y -= 1;
             }
             flips_count += 1;
-            
+
             if self.t[self.t[0] as usize] == 0 {
                 break;
             }
@@ -62,10 +62,10 @@ impl Pfannkuch {
     fn tk(&mut self, n_param: i32) {
         let mut p_count = 0; // Permutation counter index, Go's 'i' in tk
         let mut c_perm_counts = [0 as Elem; 16]; // Permutation counts, Go's 'c' in tk
-        
+
         while p_count < n_param {
-            self.rotate(p_count); 
-            
+            self.rotate(p_count);
+
             let p_count_usize = p_count as usize;
 
             if c_perm_counts[p_count_usize] >= p_count as Elem {
@@ -75,13 +75,13 @@ impl Pfannkuch {
             }
 
             c_perm_counts[p_count_usize] += 1;
-            p_count = 1; 
-            
-            self.odd = !self.odd; 
+            p_count = 1;
+
+            self.odd = !self.odd;
 
             if self.s[0] != 0 {
                 let mut f = 1;
-                if self.s[self.s[0] as usize] != 0 { 
+                if self.s[self.s[0] as usize] != 0 {
                     f = self.flip();
                 }
 
@@ -89,9 +89,11 @@ impl Pfannkuch {
                     self.maxflips = f;
                 }
 
-                if self.odd != 0 { // If odd is -1
+                if self.odd != 0 {
+                    // If odd is -1
                     self.checksum -= f;
-                } else { // If odd is 0
+                } else {
+                    // If odd is 0
                     self.checksum += f;
                 }
             }
@@ -102,12 +104,15 @@ impl Pfannkuch {
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        eprintln!("usage: {} number", args.get(0).map_or("fannkuch_redux_rust", |s| s.as_str()));
+        eprintln!(
+            "usage: {} number",
+            args.get(0).map_or("fannkuch_redux_rust", |s| s.as_str())
+        );
         process::exit(1);
     }
 
     let mut pf = Pfannkuch::new();
-    
+
     match args[1].parse::<i32>() {
         Ok(n) => pf.max_n = n,
         Err(_) => {
@@ -127,5 +132,8 @@ fn main() {
 
     pf.tk(pf.max_n);
 
-    println!("{}\nPfannkuchen({}) = {}", pf.checksum, pf.max_n, pf.maxflips);
+    println!(
+        "{}\nPfannkuchen({}) = {}",
+        pf.checksum, pf.max_n, pf.maxflips
+    );
 }

--- a/fannkuch-redux/rust/main.rs
+++ b/fannkuch-redux/rust/main.rs
@@ -1,35 +1,25 @@
 use std::env;
 use std::process;
 
-type Elem = i32;
+type Elem = u32;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct Pfannkuch {
     s: [Elem; 16],
     t: [Elem; 16],
-    maxflips: i32,
-    max_n: i32,
-    odd: i32,
+    maxflips: u32,
+    max_n: u32,
+    odd: u32,
     checksum: i32,
 }
 
 impl Pfannkuch {
-    fn new() -> Self {
-        Pfannkuch {
-            s: [0; 16],
-            t: [0; 16],
-            maxflips: 0,
-            max_n: 0,
-            odd: 0, // Initialized to 0
-            checksum: 0,
+    fn flip(&mut self, n_param: u32) -> u32 {
+        for i in 0..(n_param as usize) {
+            self.t[i] = self.s[i];
         }
-    }
 
-    fn flip(&mut self) -> i32 {
         let mut flips_count = 1;
-
-        let current_max_n = self.max_n as usize;
-        self.t[..current_max_n].copy_from_slice(&self.s[..current_max_n]);
 
         loop {
             let mut x: usize = 0;
@@ -40,16 +30,18 @@ impl Pfannkuch {
                 x += 1;
                 y -= 1;
             }
+
             flips_count += 1;
 
             if self.t[self.t[0] as usize] == 0 {
                 break;
             }
         }
+
         flips_count
     }
 
-    fn rotate(&mut self, n: i32) {
+    fn rotate(&mut self, n: u32) {
         let c = self.s[0];
         let n_usize = n as usize;
         for i in 0..n_usize {
@@ -59,7 +51,7 @@ impl Pfannkuch {
     }
 
     // n_param is self.max_n from main, which is the N for Fannkuch.
-    fn tk(&mut self, n_param: i32) {
+    fn tk(&mut self, n_param: u32) {
         let mut p_count = 0; // Permutation counter index, Go's 'i' in tk
         let mut c_perm_counts = [0 as Elem; 16]; // Permutation counts, Go's 'c' in tk
 
@@ -76,13 +68,14 @@ impl Pfannkuch {
 
             c_perm_counts[p_count_usize] += 1;
             p_count = 1;
-
             self.odd = !self.odd;
 
-            if self.s[0] != 0 {
+            let idx = self.s[0] as usize;
+            if idx != 0 {
                 let mut f = 1;
-                if self.s[self.s[0] as usize] != 0 {
-                    f = self.flip();
+
+                if self.s[idx] != 0 {
+                    f = self.flip(n_param);
                 }
 
                 if f > self.maxflips {
@@ -90,11 +83,11 @@ impl Pfannkuch {
                 }
 
                 if self.odd != 0 {
-                    // If odd is -1
-                    self.checksum -= f;
+                    // not odd
+                    self.checksum -= f as i32;
                 } else {
-                    // If odd is 0
-                    self.checksum += f;
+                    // odd
+                    self.checksum += f as i32;
                 }
             }
         }
@@ -111,9 +104,9 @@ fn main() {
         process::exit(1);
     }
 
-    let mut pf = Pfannkuch::new();
+    let mut pf = Pfannkuch::default(); // zero initialize by default
 
-    match args[1].parse::<i32>() {
+    match args[1].parse::<u32>() {
         Ok(n) => pf.max_n = n,
         Err(_) => {
             eprintln!("Error: '{}' is not a valid number.", args[1]);

--- a/fannkuch-redux/rust/main.rs
+++ b/fannkuch-redux/rust/main.rs
@@ -103,11 +103,13 @@ fn main() {
         Some(number_str) => number_str,
         None => {
             // no number argument
-            let name = prog_name.unwrap_or("fannkuch_redux_rust".to_string());
+            let name = prog_name.as_deref().unwrap_or("fannkuch_redux_rust");
             eprintln!("usage: {name} number");
             process::exit(1);
         }
     };
+
+    let verify = args.next().as_deref() == Some("v");
 
     let mut pf = Pfannkuch::default(); // zero initialize by default
 
@@ -129,9 +131,10 @@ fn main() {
     }
 
     pf.tk(pf.max_n);
-
-    println!(
-        "{}\nPfannkuchen({}) = {}",
-        pf.checksum, pf.max_n, pf.maxflips
-    );
+    if verify {
+        println!(
+            "{}\nPfannkuchen({}) = {}",
+            pf.checksum, pf.max_n, pf.maxflips
+        );
+    }
 }

--- a/fannkuch-redux/zig/main.zig
+++ b/fannkuch-redux/zig/main.zig
@@ -82,6 +82,9 @@ pub fn main(init: std.process.Init) !void {
     const arg = it.next() orelse return error.MissingArgs;
     const max_n = try std.fmt.parseInt(usize, arg, 10);
 
+    const verify_arg = it.next();
+    const verify = verify_arg != null and std.mem.eql(u8, verify_arg.?, "v");
+
     if (max_n < 1 or max_n > 15) {
         stderr.print("n must be 1-15\n", .{});
         return error.InvalidRange;
@@ -103,5 +106,7 @@ pub fn main(init: std.process.Init) !void {
 
     f.tk();
 
-    stdout.print("{d}\nPfannkuchen({d}) = {d}\n", .{ f.checksum, max_n, f.maxflips });
+    if (verify) {
+        stdout.print("{d}\nPfannkuchen({d}) = {d}\n", .{ f.checksum, max_n, f.maxflips });
+    }
 }

--- a/fasta/c/main.c
+++ b/fasta/c/main.c
@@ -28,27 +28,30 @@ static void accumulate_probabilities(AminoAcid* genelist, int len) {
     }
 }
 
-static void repeat_fasta(const char* s, int slen, int count, FILE* out) {
+static void repeat_fasta(const char* s, int slen, int count, FILE* out, int verify) {
     int pos = 0;
     char s2[WIDTH + slen];
     memcpy(s2, s, slen);
     memcpy(s2 + slen, s, WIDTH);
     while (count > 0) {
         int line = min(WIDTH, count);
-        fwrite(s2 + pos, 1, line, out);
-        fputc('\n', out);
+        if (verify) {
+            fwrite(s2 + pos, 1, line, out);
+            fputc('\n', out);
+        }
         pos += line;
         if (pos >= slen) pos -= slen;
         count -= line;
     }
 }
 
+
 static uint32_t lastrandom = 42;
 #define IM 139968
 #define IA 3877
 #define IC 29573
 
-static void random_fasta(AminoAcid* genelist, int len, int count, FILE* out) {
+static void random_fasta(AminoAcid* genelist, int len, int count, FILE* out, int verify) {
     char buf[WIDTH + 1];
     while (count > 0) {
         int line = min(WIDTH, count);
@@ -63,7 +66,9 @@ static void random_fasta(AminoAcid* genelist, int len, int count, FILE* out) {
             }
         }
         buf[line] = '\n';
-        fwrite(buf, 1, line + 1, out);
+        if (verify) {
+            fwrite(buf, 1, line + 1, out);
+        }
         count -= line;
     }
 }
@@ -73,6 +78,7 @@ int main(int argc, char* argv[]) {
     if (argc > 1) {
         n = atoi(argv[1]);
     }
+    int verify = argc > 2 && strcmp(argv[2], "v") == 0;
 
     AminoAcid iub[] = {
         {0.27, 'a'}, {0.12, 'c'}, {0.12, 'g'}, {0.27, 't'},
@@ -102,14 +108,11 @@ int main(int argc, char* argv[]) {
         "AGGCGGAGGTTGCAGTGAGCCGAGATCGCGCCACTGCACTCC"
         "AGCCTGGGCGACAGAGCGAGACTCCGTCTCAAAAA";
 
-    printf(">ONE Homo sapiens alu\n");
-    repeat_fasta(alu, strlen(alu), 2 * n, stdout);
-
-    printf(">TWO IUB ambiguity codes\n");
-    random_fasta(iub, iub_len, 3 * n, stdout);
-
-    printf(">THREE Homo sapiens frequency\n");
-    random_fasta(homosapiens, homosapiens_len, 5 * n, stdout);
-
+    if (verify) printf(">ONE Homo sapiens alu\n");
+    repeat_fasta(alu, strlen(alu), 2 * n, stdout, verify);
+    if (verify) printf(">TWO IUB ambiguity codes\n");
+    random_fasta(iub, iub_len, 3 * n, stdout, verify);
+    if (verify) printf(">THREE Homo sapiens frequency\n");
+    random_fasta(homosapiens, homosapiens_len, 5 * n, stdout, verify);
     return 0;
 }

--- a/fasta/go/main.go
+++ b/fasta/go/main.go
@@ -45,15 +45,17 @@ func AccumulateProbabilities(genelist []AminoAcid) {
 // It stops after generating count characters.
 // After each WIDTH characters it prints a newline.
 // It assumes that WIDTH <= len(s) + 1.
-func RepeatFasta(s []byte, count int) {
+func RepeatFasta(s []byte, count int, verify bool) {
 	pos := 0
 	s2 := make([]byte, len(s)+WIDTH)
 	copy(s2, s)
 	copy(s2[len(s):], s)
 	for count > 0 {
 		line := min(WIDTH, count)
-		out.Write(s2[pos : pos+line])
-		out.WriteByte('\n')
+		if verify {
+			out.Write(s2[pos : pos+line])
+			out.WriteByte('\n')
+		}
 		pos += line
 		if pos >= len(s) {
 			pos -= len(s)
@@ -61,7 +63,6 @@ func RepeatFasta(s []byte, count int) {
 		count -= line
 	}
 }
-
 var lastrandom uint32 = 42
 
 const (
@@ -78,7 +79,7 @@ const (
 // RandomFasta then prints the character of the array element.
 // This sequence is repeated count times.
 // Between each WIDTH consecutive characters, the function prints a newline.
-func RandomFasta(genelist []AminoAcid, count int) {
+func RandomFasta(genelist []AminoAcid, count int, verify bool) {
 	buf := make([]byte, WIDTH+1)
 	for count > 0 {
 		line := min(WIDTH, count)
@@ -94,7 +95,9 @@ func RandomFasta(genelist []AminoAcid, count int) {
 			}
 		}
 		buf[line] = '\n'
-		out.Write(buf[0 : line+1])
+		if verify {
+			out.Write(buf[0 : line+1])
+		}
 		count -= line
 	}
 }
@@ -107,6 +110,8 @@ func main() {
 	if flag.NArg() > 0 {
 		n, _ = strconv.Atoi(flag.Arg(0))
 	}
+
+	verify := flag.NArg() > 1 && flag.Arg(1) == "v"
 
 	iub := []AminoAcid{
 		AminoAcid{0.27, 'a'},
@@ -145,10 +150,16 @@ func main() {
 			"AGGCGGAGGTTGCAGTGAGCCGAGATCGCGCCACTGCACTCC" +
 			"AGCCTGGGCGACAGAGCGAGACTCCGTCTCAAAAA")
 
-	out.WriteString(">ONE Homo sapiens alu\n")
-	RepeatFasta(alu, 2*n)
-	out.WriteString(">TWO IUB ambiguity codes\n")
-	RandomFasta(iub, 3*n)
-	out.WriteString(">THREE Homo sapiens frequency\n")
-	RandomFasta(homosapiens, 5*n)
+	if verify {
+		out.WriteString(">ONE Homo sapiens alu\n")
+	}
+	RepeatFasta(alu, 2*n, verify)
+	if verify {
+		out.WriteString(">TWO IUB ambiguity codes\n")
+	}
+	RandomFasta(iub, 3*n, verify)
+	if verify {
+		out.WriteString(">THREE Homo sapiens frequency\n")
+	}
+	RandomFasta(homosapiens, 5*n, verify)
 }

--- a/fasta/go/main.go
+++ b/fasta/go/main.go
@@ -63,6 +63,7 @@ func RepeatFasta(s []byte, count int, verify bool) {
 		count -= line
 	}
 }
+
 var lastrandom uint32 = 42
 
 const (
@@ -114,28 +115,28 @@ func main() {
 	verify := flag.NArg() > 1 && flag.Arg(1) == "v"
 
 	iub := []AminoAcid{
-		AminoAcid{0.27, 'a'},
-		AminoAcid{0.12, 'c'},
-		AminoAcid{0.12, 'g'},
-		AminoAcid{0.27, 't'},
-		AminoAcid{0.02, 'B'},
-		AminoAcid{0.02, 'D'},
-		AminoAcid{0.02, 'H'},
-		AminoAcid{0.02, 'K'},
-		AminoAcid{0.02, 'M'},
-		AminoAcid{0.02, 'N'},
-		AminoAcid{0.02, 'R'},
-		AminoAcid{0.02, 'S'},
-		AminoAcid{0.02, 'V'},
-		AminoAcid{0.02, 'W'},
-		AminoAcid{0.02, 'Y'},
+		{0.27, 'a'},
+		{0.12, 'c'},
+		{0.12, 'g'},
+		{0.27, 't'},
+		{0.02, 'B'},
+		{0.02, 'D'},
+		{0.02, 'H'},
+		{0.02, 'K'},
+		{0.02, 'M'},
+		{0.02, 'N'},
+		{0.02, 'R'},
+		{0.02, 'S'},
+		{0.02, 'V'},
+		{0.02, 'W'},
+		{0.02, 'Y'},
 	}
 
 	homosapiens := []AminoAcid{
-		AminoAcid{0.3029549426680, 'a'},
-		AminoAcid{0.1979883004921, 'c'},
-		AminoAcid{0.1975473066391, 'g'},
-		AminoAcid{0.3015094502008, 't'},
+		{0.3029549426680, 'a'},
+		{0.1979883004921, 'c'},
+		{0.1975473066391, 'g'},
+		{0.3015094502008, 't'},
 	}
 
 	AccumulateProbabilities(iub)

--- a/fasta/rust/main.rs
+++ b/fasta/rust/main.rs
@@ -98,10 +98,22 @@ fn main() {
     ];
 
     let mut homosapiens = [
-        AminoAcid { p: 0.3029549426680, c: b'a' },
-        AminoAcid { p: 0.1979883004921, c: b'c' },
-        AminoAcid { p: 0.1975473066391, c: b'g' },
-        AminoAcid { p: 0.3015094502008, c: b't' },
+        AminoAcid {
+            p: 0.3029549426680,
+            c: b'a',
+        },
+        AminoAcid {
+            p: 0.1979883004921,
+            c: b'c',
+        },
+        AminoAcid {
+            p: 0.1975473066391,
+            c: b'g',
+        },
+        AminoAcid {
+            p: 0.3015094502008,
+            c: b't',
+        },
     ];
 
     accumulate_probabilities(&mut iub);

--- a/fasta/rust/main.rs
+++ b/fasta/rust/main.rs
@@ -23,7 +23,7 @@ fn accumulate_probabilities(genelist: &mut [AminoAcid]) {
     }
 }
 
-fn repeat_fasta(s: &[u8], count: usize, out: &mut dyn Write) {
+fn repeat_fasta(s: &[u8], count: usize, out: &mut dyn Write, verify: bool) {
     let slen = s.len();
     let mut s2 = Vec::with_capacity(slen + WIDTH);
     s2.extend_from_slice(s);
@@ -32,8 +32,10 @@ fn repeat_fasta(s: &[u8], count: usize, out: &mut dyn Write) {
     let mut remaining = count;
     while remaining > 0 {
         let line = WIDTH.min(remaining);
-        out.write_all(&s2[pos..pos + line]).unwrap();
-        out.write_all(b"\n").unwrap();
+        if verify {
+            out.write_all(&s2[pos..pos + line]).unwrap();
+            out.write_all(b"\n").unwrap();
+        }
         pos += line;
         if pos >= slen {
             pos -= slen;
@@ -47,7 +49,7 @@ const IM: u32 = 139968;
 const IA: u32 = 3877;
 const IC: u32 = 29573;
 
-fn random_fasta(genelist: &[AminoAcid], count: usize, out: &mut dyn Write) {
+fn random_fasta(genelist: &[AminoAcid], count: usize, out: &mut dyn Write, verify: bool) {
     let mut buf = vec![0u8; WIDTH + 1];
     let mut remaining = count;
     while remaining > 0 {
@@ -66,16 +68,22 @@ fn random_fasta(genelist: &[AminoAcid], count: usize, out: &mut dyn Write) {
             }
         }
         buf[line] = b'\n';
-        out.write_all(&buf[..line + 1]).unwrap();
+        if verify {
+            out.write_all(&buf[..line + 1]).unwrap();
+        }
         remaining -= line;
     }
 }
 
 fn main() {
-    let n = match env::args().nth(1) {
+    let mut args = env::args();
+    let _prog_name = args.next();
+    let n = match args.next() {
         Some(s) => s.parse::<usize>().unwrap_or(0),
         None => 0,
     };
+
+    let verify = args.next().as_deref() == Some("v");
 
     let mut iub = [
         AminoAcid { p: 0.27, c: b'a' },
@@ -128,12 +136,16 @@ AGCCTGGGCGACAGAGCGAGACTCCGTCTCAAAAA";
     let stdout = io::stdout();
     let mut out = stdout.lock();
 
-    out.write_all(b">ONE Homo sapiens alu\n").unwrap();
-    repeat_fasta(alu, 2 * n, &mut out);
-
-    out.write_all(b">TWO IUB ambiguity codes\n").unwrap();
-    random_fasta(&iub, 3 * n, &mut out);
-
-    out.write_all(b">THREE Homo sapiens frequency\n").unwrap();
-    random_fasta(&homosapiens, 5 * n, &mut out);
+    if verify {
+        out.write_all(b">ONE Homo sapiens alu\n").unwrap();
+    }
+    repeat_fasta(alu, 2 * n, &mut out, verify);
+    if verify {
+        out.write_all(b">TWO IUB ambiguity codes\n").unwrap();
+    }
+    random_fasta(&iub, 3 * n, &mut out, verify);
+    if verify {
+        out.write_all(b">THREE Homo sapiens frequency\n").unwrap();
+    }
+    random_fasta(&homosapiens, 5 * n, &mut out, verify);
 }

--- a/fasta/rust/main.rs
+++ b/fasta/rust/main.rs
@@ -72,11 +72,9 @@ fn random_fasta(genelist: &[AminoAcid], count: usize, out: &mut dyn Write) {
 }
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    let n = if args.len() > 1 {
-        args[1].parse::<usize>().unwrap_or(0)
-    } else {
-        0
+    let n = match env::args().nth(1) {
+        Some(s) => s.parse::<usize>().unwrap_or(0),
+        None => 0,
     };
 
     let mut iub = [

--- a/fasta/zig/main.zig
+++ b/fasta/zig/main.zig
@@ -14,7 +14,7 @@ fn accumulateProbabilities(genelist: []AminoAcid) void {
     }
 }
 
-fn repeatFasta(allocator: std.mem.Allocator, s: []const u8, count: usize, out: anytype) !void {
+fn repeatFasta(allocator: std.mem.Allocator, s: []const u8, count: usize, out: anytype, verify: bool) !void {
     var pos: usize = 0;
     var s2 = try allocator.alloc(u8, s.len + WIDTH);
     defer allocator.free(s2);
@@ -25,7 +25,9 @@ fn repeatFasta(allocator: std.mem.Allocator, s: []const u8, count: usize, out: a
     var remaining = count;
     while (remaining > 0) {
         const line = @min(WIDTH, remaining);
-        out.print("{s}\n", .{s2[pos .. pos + line]});
+        if (verify) {
+            out.print("{s}\n", .{s2[pos .. pos + line]});
+        }
         pos += line;
         if (pos >= s.len) pos -= s.len;
         remaining -= line;
@@ -37,7 +39,7 @@ const IM: u32 = 139968;
 const IA: u32 = 3877;
 const IC: u32 = 29573;
 
-fn randomFasta(genelist: []const AminoAcid, count: usize, out: anytype) !void {
+fn randomFasta(genelist: []const AminoAcid, count: usize, out: anytype, verify: bool) !void {
     var buf: [WIDTH + 1]u8 = undefined;
     var remaining = count;
     while (remaining > 0) {
@@ -53,7 +55,9 @@ fn randomFasta(genelist: []const AminoAcid, count: usize, out: anytype) !void {
             }
         }
         buf[line] = '\n';
-        out.print("{s}", .{buf[0 .. line + 1]});
+        if (verify) {
+            out.print("{s}", .{buf[0 .. line + 1]});
+        }
         remaining -= line;
     }
 }
@@ -71,6 +75,9 @@ pub fn main(init: std.process.Init) !void {
     if (max_n < 1 or max_n > 50000000) {
         return error.InvalidRange;
     }
+
+    const verify_arg = it.next();
+    const verify = verify_arg != null and std.mem.eql(u8, verify_arg.?, "v");
 
     var iub = [_]AminoAcid{
         AminoAcid{ .p = 0.27, .c = 'a' },
@@ -105,12 +112,12 @@ pub fn main(init: std.process.Init) !void {
         "TGGTGGCGCGCGCCTGTAATCCCAGCTACTCGGGAGGCTGAGGCAGGAGAATCGCTTGAACCCGGGAGGCGG" ++
         "AGGTTGCAGTGAGCCGAGATCGCGCCACTGCACTCCAGCCTGGGCGACAGAGCGAGACTCCGTCTCAAAAA";
 
-    stdout.print(">ONE Homo sapiens alu\n", .{});
-    try repeatFasta(allocator, alu, 2 * max_n, stdout);
+    if (verify) stdout.print(">ONE Homo sapiens alu\n", .{});
+    try repeatFasta(allocator, alu, 2 * max_n, stdout, verify);
 
-    stdout.print(">TWO IUB ambiguity codes\n", .{});
-    try randomFasta(iub[0..], 3 * max_n, stdout);
+    if (verify) stdout.print(">TWO IUB ambiguity codes\n", .{});
+    try randomFasta(iub[0..], 3 * max_n, stdout, verify);
 
-    stdout.print(">THREE Homo sapiens frequency\n", .{});
-    try randomFasta(homosapiens[0..], 5 * max_n, stdout);
+    if (verify) stdout.print(">THREE Homo sapiens frequency\n", .{});
+    try randomFasta(homosapiens[0..], 5 * max_n, stdout, verify);
 }

--- a/n-body-nosqrt/c/main.c
+++ b/n-body-nosqrt/c/main.c
@@ -9,6 +9,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define pi 3.141592653589793
 #define solar_mass (4 * pi * pi)
@@ -146,15 +147,23 @@ struct planet bodies[NBODIES] = {
 }
 };
 
-int main(int argc, char ** argv)
+int main(int argc, char **argv)
 {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <number_of_steps>\n", argv[0]);
+        return 1;
+    }
     int n = atoi(argv[1]);
-    int i;
+    int verify = argc > 2 && strcmp(argv[2], "v") == 0;
 
     offset_momentum(NBODIES, bodies);
-    printf ("%.9f\n", energy(NBODIES, bodies));
-    for (i = 1; i <= n; i++)
+    double start_energy = energy(NBODIES, bodies);
+    if (verify)
+        printf("%.9f\n", start_energy);
+    for (int i = 1; i <= n; i++)
         advance(NBODIES, bodies, 0.01);
-    printf ("%.9f\n", energy(NBODIES, bodies));
+    double end_energy = energy(NBODIES, bodies);
+    if (verify)
+        printf("%.9f\n", end_energy);
     return 0;
 }

--- a/n-body-nosqrt/go/main.go
+++ b/n-body-nosqrt/go/main.go
@@ -8,16 +8,16 @@ import (
 )
 
 const (
-	pi		  = 3.141592653589793
+	pi          = 3.141592653589793
 	solarMass   = 4 * pi * pi
 	daysPerYear = 365.24
-	tol		 = 1e-5
+	tol         = 1e-5
 )
 
 type Planet struct {
-	x, y, z	float64
+	x, y, z    float64
 	vx, vy, vz float64
-	mass	   float64
+	mass       float64
 }
 
 func sqrt_newton(a, tol float64) float64 {

--- a/n-body-nosqrt/go/main.go
+++ b/n-body-nosqrt/go/main.go
@@ -8,16 +8,16 @@ import (
 )
 
 const (
-	pi          = 3.141592653589793
+	pi		  = 3.141592653589793
 	solarMass   = 4 * pi * pi
 	daysPerYear = 365.24
-	tol         = 1e-5
+	tol		 = 1e-5
 )
 
 type Planet struct {
-	x, y, z    float64
+	x, y, z	float64
 	vx, vy, vz float64
-	mass       float64
+	mass	   float64
 }
 
 func sqrt_newton(a, tol float64) float64 {
@@ -138,11 +138,27 @@ var bodies = [nbodies]Planet{
 }
 
 func main() {
-	n, _ := strconv.Atoi(os.Args[1])
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <number_of_steps>\n", os.Args[0])
+		os.Exit(1)
+	}
+	n, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Could not parse number of steps '%s'\n", os.Args[1])
+		os.Exit(1)
+	}
+	verify := len(os.Args) > 2 && os.Args[2] == "v"
+
 	offsetMomentum(nbodies, bodies[:])
-	fmt.Printf("%.9f\n", energy(nbodies, bodies[:]))
+	startEnergy := energy(nbodies, bodies[:])
+	if verify {
+		fmt.Printf("%.9f\n", startEnergy)
+	}
 	for i := 1; i <= n; i++ {
 		advance(nbodies, bodies[:], 0.01)
 	}
-	fmt.Printf("%.9f\n", energy(nbodies, bodies[:]))
+	endEnergy := energy(nbodies, bodies[:])
+	if verify {
+		fmt.Printf("%.9f\n", endEnergy)
+	}
 }

--- a/n-body-nosqrt/rust/main.rs
+++ b/n-body-nosqrt/rust/main.rs
@@ -50,7 +50,8 @@ fn advance(bodies: &mut [Planet], dt: f64) {
             let distance_squared = dx * dx + dy * dy + dz * dz;
             let distance = sqrt_newton(distance_squared, TOL);
 
-            if distance == 0.0 { // Or handle distance_squared == 0.0 earlier
+            if distance == 0.0 {
+                // Or handle distance_squared == 0.0 earlier
                 continue;
             }
 
@@ -88,8 +89,9 @@ fn energy(bodies: &[Planet]) -> f64 {
             let dz = b1.z - b2.z;
             let distance_squared = dx * dx + dy * dy + dz * dz;
             let distance = sqrt_newton(distance_squared, TOL);
-            
-            if distance == 0.0 { // Avoid division by zero
+
+            if distance == 0.0 {
+                // Avoid division by zero
                 continue;
             }
             e -= (b1.mass * b2.mass) / distance;
@@ -107,7 +109,8 @@ fn offset_momentum(bodies: &mut [Planet]) {
         py += body.vy * body.mass;
         pz += body.vz * body.mass;
     }
-    if !bodies.is_empty() { // Ensure bodies is not empty before indexing
+    if !bodies.is_empty() {
+        // Ensure bodies is not empty before indexing
         bodies[0].vx = -px / SOLAR_MASS;
         bodies[0].vy = -py / SOLAR_MASS;
         bodies[0].vz = -pz / SOLAR_MASS;
@@ -118,10 +121,18 @@ const NBODIES: usize = 5;
 
 fn initial_bodies() -> [Planet; NBODIES] {
     [
-        Planet { // sun
-            x: 0.0, y: 0.0, z: 0.0, vx: 0.0, vy: 0.0, vz: 0.0, mass: SOLAR_MASS,
+        Planet {
+            // sun
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            vx: 0.0,
+            vy: 0.0,
+            vz: 0.0,
+            mass: SOLAR_MASS,
         },
-        Planet { // jupiter
+        Planet {
+            // jupiter
             x: 4.84143144246472090e+00,
             y: -1.16032004402742839e+00,
             z: -1.03622044471123109e-01,
@@ -130,7 +141,8 @@ fn initial_bodies() -> [Planet; NBODIES] {
             vz: -6.90460016972063023e-05 * DAYS_PER_YEAR,
             mass: 9.54791938424326609e-04 * SOLAR_MASS,
         },
-        Planet { // saturn
+        Planet {
+            // saturn
             x: 8.34336671824457987e+00,
             y: 4.12479856412430479e+00,
             z: -4.03523417114321381e-01,
@@ -139,7 +151,8 @@ fn initial_bodies() -> [Planet; NBODIES] {
             vz: 2.30417297573763929e-05 * DAYS_PER_YEAR,
             mass: 2.85885980666130812e-04 * SOLAR_MASS,
         },
-        Planet { // uranus
+        Planet {
+            // uranus
             x: 1.28943695621391310e+01,
             y: -1.51111514016986312e+01,
             z: -2.23307578892655734e-01,
@@ -148,7 +161,8 @@ fn initial_bodies() -> [Planet; NBODIES] {
             vz: -2.96589568540237556e-05 * DAYS_PER_YEAR,
             mass: 4.36624404335156298e-05 * SOLAR_MASS,
         },
-        Planet { // neptune
+        Planet {
+            // neptune
             x: 1.53796971148509165e+01,
             y: -2.59193146099879641e+01,
             z: 1.79258772950371181e-01,
@@ -163,7 +177,10 @@ fn initial_bodies() -> [Planet; NBODIES] {
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        eprintln!("Usage: {} <number_of_steps>", args.get(0).map_or("nbody_rust_nosqrt", |s| s.as_str()));
+        eprintln!(
+            "Usage: {} <number_of_steps>",
+            args.get(0).map_or("nbody_rust_nosqrt", |s| s.as_str())
+        );
         process::exit(1);
     }
 

--- a/n-body-nosqrt/rust/main.rs
+++ b/n-body-nosqrt/rust/main.rs
@@ -175,31 +175,30 @@ fn initial_bodies() -> [Planet; NBODIES] {
 }
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        eprintln!(
-            "Usage: {} <number_of_steps>",
-            args.get(0).map_or("nbody_rust_nosqrt", |s| s.as_str())
-        );
-        process::exit(1);
-    }
+    let mut args = env::args();
+    let prog_name = args.next();
+    let steps = args.next();
 
-    let n_steps: usize = match args[1].parse() {
-        Ok(n) => n,
-        Err(_) => {
-            eprintln!("Error: Could not parse number of steps '{}'", args[1]);
+    let n_steps: usize = match steps {
+        None => {
+            let name = prog_name.as_deref().unwrap_or("nbody_rust_nosqrt");
+            eprintln!("Usage: {name} <number_of_steps>");
             process::exit(1);
         }
+        Some(s) => match s.parse() {
+            Ok(n) => n,
+            Err(_) => {
+                eprintln!("Error: Could not parse number of steps '{s}'");
+                process::exit(1);
+            }
+        },
     };
-
     let mut bodies_arr = initial_bodies();
     offset_momentum(&mut bodies_arr);
-
     println!("{:.9}", energy(&bodies_arr));
 
     for _ in 0..n_steps {
         advance(&mut bodies_arr, 0.01);
     }
-
     println!("{:.9}", energy(&bodies_arr));
 }

--- a/n-body-nosqrt/rust/main.rs
+++ b/n-body-nosqrt/rust/main.rs
@@ -178,7 +178,7 @@ fn main() {
     let mut args = env::args();
     let prog_name = args.next();
     let steps = args.next();
-
+    let verify = args.next().as_deref() == Some("v");
     let n_steps: usize = match steps {
         None => {
             let name = prog_name.as_deref().unwrap_or("nbody_rust_nosqrt");
@@ -195,10 +195,15 @@ fn main() {
     };
     let mut bodies_arr = initial_bodies();
     offset_momentum(&mut bodies_arr);
-    println!("{:.9}", energy(&bodies_arr));
-
+    let starting_energy = energy(&bodies_arr);
+    if verify {
+        println!("{:.9}", starting_energy);
+    }
     for _ in 0..n_steps {
         advance(&mut bodies_arr, 0.01);
     }
-    println!("{:.9}", energy(&bodies_arr));
+    let ending_energy = energy(&bodies_arr);
+    if verify {
+        println!("{:.9}", ending_energy);
+    }
 }

--- a/n-body-nosqrt/zig/main.zig
+++ b/n-body-nosqrt/zig/main.zig
@@ -156,13 +156,21 @@ pub fn main(init: std.process.Init) !void {
     const arg = it.next() orelse return error.MissingArgs;
     const n = try std.fmt.parseInt(usize, arg, 10);
     const bodies = Bodies[0..];
+    const verify_arg = it.next();
+    const verify = verify_arg != null and std.mem.eql(u8, verify_arg.?, "v");
 
     offsetMomentum(bodies);
-    stdout.print("{d:.9}\n", .{energy(bodies)});
+    const start_energy = energy(bodies);
+    if (verify) {
+        stdout.print("{d:.9}\n", .{start_energy});
+    }
 
     for (0..n) |_| {
         advance(bodies, 0.01);
     }
 
-    stdout.print("{d:.9}\n", .{energy(bodies)});
+    const end_energy = energy(bodies);
+    if (verify) {
+        stdout.print("{d:.9}\n", .{end_energy});
+    }
 }

--- a/n-body/c/main.c
+++ b/n-body/c/main.c
@@ -9,6 +9,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define pi 3.141592653589793
 #define solar_mass (4 * pi * pi)
@@ -128,15 +129,23 @@ struct planet bodies[NBODIES] = {
 }
 };
 
-int main(int argc, char ** argv)
+int main(int argc, char **argv)
 {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <number_of_steps>\n", argv[0]);
+        return 1;
+    }
     int n = atoi(argv[1]);
-    int i;
+    int verify = argc > 2 && strcmp(argv[2], "v") == 0;
 
     offset_momentum(NBODIES, bodies);
-    printf ("%.9f\n", energy(NBODIES, bodies));
-    for (i = 1; i <= n; i++)
+    double start_energy = energy(NBODIES, bodies);
+    if (verify)
+        printf("%.9f\n", start_energy);
+    for (int i = 1; i <= n; i++)
         advance(NBODIES, bodies, 0.01);
-    printf ("%.9f\n", energy(NBODIES, bodies));
+    double end_energy = energy(NBODIES, bodies);
+    if (verify)
+        printf("%.9f\n", end_energy);
     return 0;
 }

--- a/n-body/go/main.go
+++ b/n-body/go/main.go
@@ -8,15 +8,15 @@ import (
 )
 
 const (
-	pi		  = 3.141592653589793
+	pi          = 3.141592653589793
 	solarMass   = 4 * pi * pi
 	daysPerYear = 365.24
 )
 
 type Planet struct {
-	x, y, z	float64
+	x, y, z    float64
 	vx, vy, vz float64
-	mass	   float64
+	mass       float64
 }
 
 func advance(nbodies int, bodies []Planet, dt float64) {

--- a/n-body/go/main.go
+++ b/n-body/go/main.go
@@ -8,15 +8,15 @@ import (
 )
 
 const (
-	pi          = 3.141592653589793
+	pi		  = 3.141592653589793
 	solarMass   = 4 * pi * pi
 	daysPerYear = 365.24
 )
 
 type Planet struct {
-	x, y, z    float64
+	x, y, z	float64
 	vx, vy, vz float64
-	mass       float64
+	mass	   float64
 }
 
 func advance(nbodies int, bodies []Planet, dt float64) {
@@ -120,11 +120,27 @@ var bodies = [nbodies]Planet{
 }
 
 func main() {
-	n, _ := strconv.Atoi(os.Args[1])
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <number_of_steps>\n", os.Args[0])
+		os.Exit(1)
+	}
+	n, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Could not parse number of steps '%s'\n", os.Args[1])
+		os.Exit(1)
+	}
+	verify := len(os.Args) > 2 && os.Args[2] == "v"
+
 	offsetMomentum(nbodies, bodies[:])
-	fmt.Printf("%.9f\n", energy(nbodies, bodies[:]))
+	startEnergy := energy(nbodies, bodies[:])
+	if verify {
+		fmt.Printf("%.9f\n", startEnergy)
+	}
 	for i := 1; i <= n; i++ {
 		advance(nbodies, bodies[:], 0.01)
 	}
-	fmt.Printf("%.9f\n", energy(nbodies, bodies[:]))
+	endEnergy := energy(nbodies, bodies[:])
+	if verify {
+		fmt.Printf("%.9f\n", endEnergy)
+	}
 }

--- a/n-body/rust/main.rs
+++ b/n-body/rust/main.rs
@@ -142,31 +142,29 @@ fn initial_bodies() -> [Planet; NBODIES] {
 }
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        eprintln!(
-            "Usage: {} <number_of_steps>",
-            args.get(0).map_or("nbody_rust", |s| s.as_str())
-        );
-        process::exit(1);
-    }
+    let mut args = env::args();
+    let prog = args.next();
 
-    let n_steps: usize = match args[1].parse() {
-        Ok(n) => n,
-        Err(_) => {
-            eprintln!("Error: Could not parse number of steps '{}'", args[1]);
+    let n_steps: usize = match args.next() {
+        Some(s) => match s.parse() {
+            Ok(n) => n,
+            Err(_) => {
+                eprintln!("Error: Could not parse number of steps '{}'", s);
+                process::exit(1);
+            }
+        },
+        None => {
+            let prog_name = prog.as_deref().unwrap_or("nbody_rust");
+            eprintln!("Usage: {} <number_of_steps>", prog_name);
             process::exit(1);
         }
     };
 
     let mut bodies_arr = initial_bodies();
     offset_momentum(&mut bodies_arr);
-
     println!("{:.9}", energy(&bodies_arr));
-
     for _ in 0..n_steps {
         advance(&mut bodies_arr, 0.01);
     }
-
     println!("{:.9}", energy(&bodies_arr));
 }

--- a/n-body/rust/main.rs
+++ b/n-body/rust/main.rs
@@ -88,10 +88,18 @@ const NBODIES: usize = 5;
 
 fn initial_bodies() -> [Planet; NBODIES] {
     [
-        Planet { // sun
-            x: 0.0, y: 0.0, z: 0.0, vx: 0.0, vy: 0.0, vz: 0.0, mass: SOLAR_MASS,
+        Planet {
+            // sun
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            vx: 0.0,
+            vy: 0.0,
+            vz: 0.0,
+            mass: SOLAR_MASS,
         },
-        Planet { // jupiter
+        Planet {
+            // jupiter
             x: 4.84143144246472090e+00,
             y: -1.16032004402742839e+00,
             z: -1.03622044471123109e-01,
@@ -100,7 +108,8 @@ fn initial_bodies() -> [Planet; NBODIES] {
             vz: -6.90460016972063023e-05 * DAYS_PER_YEAR,
             mass: 9.54791938424326609e-04 * SOLAR_MASS,
         },
-        Planet { // saturn
+        Planet {
+            // saturn
             x: 8.34336671824457987e+00,
             y: 4.12479856412430479e+00,
             z: -4.03523417114321381e-01,
@@ -109,7 +118,8 @@ fn initial_bodies() -> [Planet; NBODIES] {
             vz: 2.30417297573763929e-05 * DAYS_PER_YEAR,
             mass: 2.85885980666130812e-04 * SOLAR_MASS,
         },
-        Planet { // uranus
+        Planet {
+            // uranus
             x: 1.28943695621391310e+01,
             y: -1.51111514016986312e+01,
             z: -2.23307578892655734e-01,
@@ -118,7 +128,8 @@ fn initial_bodies() -> [Planet; NBODIES] {
             vz: -2.96589568540237556e-05 * DAYS_PER_YEAR,
             mass: 4.36624404335156298e-05 * SOLAR_MASS,
         },
-        Planet { // neptune
+        Planet {
+            // neptune
             x: 1.53796971148509165e+01,
             y: -2.59193146099879641e+01,
             z: 1.79258772950371181e-01,
@@ -133,7 +144,10 @@ fn initial_bodies() -> [Planet; NBODIES] {
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        eprintln!("Usage: {} <number_of_steps>", args.get(0).map_or("nbody_rust", |s| s.as_str()));
+        eprintln!(
+            "Usage: {} <number_of_steps>",
+            args.get(0).map_or("nbody_rust", |s| s.as_str())
+        );
         process::exit(1);
     }
 

--- a/n-body/rust/main.rs
+++ b/n-body/rust/main.rs
@@ -143,28 +143,34 @@ fn initial_bodies() -> [Planet; NBODIES] {
 
 fn main() {
     let mut args = env::args();
-    let prog = args.next();
-
-    let n_steps: usize = match args.next() {
+    let prog_name = args.next();
+    let steps = args.next();
+    let verify = args.next().as_deref() == Some("v");
+    let n_steps: usize = match steps {
+        None => {
+            let name = prog_name.as_deref().unwrap_or("nbody_rust");
+            eprintln!("Usage: {name} <number_of_steps>");
+            process::exit(1);
+        }
         Some(s) => match s.parse() {
             Ok(n) => n,
             Err(_) => {
-                eprintln!("Error: Could not parse number of steps '{}'", s);
+                eprintln!("Error: Could not parse number of steps '{s}'");
                 process::exit(1);
             }
         },
-        None => {
-            let prog_name = prog.as_deref().unwrap_or("nbody_rust");
-            eprintln!("Usage: {} <number_of_steps>", prog_name);
-            process::exit(1);
-        }
     };
-
     let mut bodies_arr = initial_bodies();
     offset_momentum(&mut bodies_arr);
-    println!("{:.9}", energy(&bodies_arr));
+    let starting_energy = energy(&bodies_arr);
+    if verify {
+        println!("{:.9}", starting_energy);
+    }
     for _ in 0..n_steps {
         advance(&mut bodies_arr, 0.01);
     }
-    println!("{:.9}", energy(&bodies_arr));
+    let ending_energy = energy(&bodies_arr);
+    if verify {
+        println!("{:.9}", ending_energy);
+    }
 }

--- a/n-body/zig/main.zig
+++ b/n-body/zig/main.zig
@@ -139,13 +139,21 @@ pub fn main(init: std.process.Init) !void {
     const arg = it.next() orelse return error.MissingArgs;
     const n = try std.fmt.parseInt(usize, arg, 10);
     const bodies = Bodies[0..];
+    const verify_arg = it.next();
+    const verify = verify_arg != null and std.mem.eql(u8, verify_arg.?, "v");
 
     offsetMomentum(bodies);
-    stdout.print("{d:.9}\n", .{energy(bodies)});
+    const start_energy = energy(bodies);
+    if (verify) {
+        stdout.print("{d:.9}\n", .{start_energy});
+    }
 
     for (0..n) |_| {
         advance(bodies, 0.01);
     }
 
-    stdout.print("{d:.9}\n", .{energy(bodies)});
+    const end_energy = energy(bodies);
+    if (verify) {
+        stdout.print("{d:.9}\n", .{end_energy});
+    }
 }

--- a/spectral-norm/c/main.c
+++ b/spectral-norm/c/main.c
@@ -40,6 +40,7 @@ int main(int argc, char *argv[]) {
     if (argc > 1) {
         n = atoi(argv[1]);
     }
+    int verify = argc > 2 && strcmp(argv[2], "v") == 0;
 
     double *u = (double *)malloc(n * sizeof(double));
     double *v = (double *)malloc(n * sizeof(double));
@@ -59,7 +60,10 @@ int main(int argc, char *argv[]) {
         vv += v[i] * v[i];
     }
 
-    printf("%0.9f\n", sqrt(vBv / vv));
+    double answer = sqrt(vBv / vv);
+    if (verify) {
+        printf("%0.9f\n", answer);
+    }
 
     free(u);
     free(v);

--- a/spectral-norm/go/main.go
+++ b/spectral-norm/go/main.go
@@ -47,6 +47,8 @@ func main() {
 		n, _ = strconv.Atoi(flag.Arg(0))
 	}
 
+	verify := flag.NArg() > 1 && flag.Arg(1) == "v"
+
 	u := make(Vec, n)
 	v := make(Vec, n)
 	for i := range u {
@@ -62,5 +64,8 @@ func main() {
 		vBv += u[i] * vi
 		vv += vi * vi
 	}
-	fmt.Printf("%0.9f\n", math.Sqrt(vBv/vv))
+	answer := math.Sqrt(vBv / vv)
+    if verify {
+        fmt.Printf("%0.9f\n", answer)
+    }
 }

--- a/spectral-norm/go/main.go
+++ b/spectral-norm/go/main.go
@@ -65,7 +65,7 @@ func main() {
 		vv += vi * vi
 	}
 	answer := math.Sqrt(vBv / vv)
-    if verify {
-        fmt.Printf("%0.9f\n", answer)
-    }
+	if verify {
+		fmt.Printf("%0.9f\n", answer)
+	}
 }

--- a/spectral-norm/rust/main.rs
+++ b/spectral-norm/rust/main.rs
@@ -34,11 +34,11 @@ fn a_times_transp(v: &mut [f64], u: &[f64]) {
 }
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    let n: usize = if args.len() > 1 {
-        args[1].parse().unwrap_or(0)
-    } else {
-        0
+    let mut args = env::args();
+    let prog = args.next();
+    let n: usize = match args.next() {
+        Some(s) => s.parse().unwrap_or(0),
+        None => 0,
     };
 
     let mut u = vec![1.0; n];

--- a/spectral-norm/rust/main.rs
+++ b/spectral-norm/rust/main.rs
@@ -41,6 +41,8 @@ fn main() {
         None => 0,
     };
 
+    let verify = args.next().as_deref() == Some("v");
+
     let mut u = vec![1.0; n];
     let mut v = vec![1.0; n];
 
@@ -56,5 +58,8 @@ fn main() {
         vv += v[i] * v[i];
     }
 
-    println!("{:.9}", (vBv / vv).sqrt());
+    let answer = (vBv / vv).sqrt();
+    if verify {
+        println!("{:.9}", answer);
+    }
 }

--- a/spectral-norm/zig/main.zig
+++ b/spectral-norm/zig/main.zig
@@ -44,6 +44,9 @@ pub fn main(init: std.process.Init) !void {
     const arg = it.next() orelse return error.MissingArgs;
     const n = try std.fmt.parseInt(usize, arg, 10);
 
+    const verify_arg = it.next();
+    const verify = verify_arg != null and std.mem.eql(u8, verify_arg.?, "v");
+
     const u = try allocator.alloc(f64, n);
     const v = try allocator.alloc(f64, n);
     defer allocator.free(u);
@@ -64,5 +67,8 @@ pub fn main(init: std.process.Init) !void {
         vv += vi * vi;
     }
 
-    stdout.print("{d:.9}\n", .{math.sqrt(vBv / vv)});
+    const answer = math.sqrt(vBv / vv);
+    if (verify) {
+        stdout.print("{d:.9}\n", .{answer});
+    }
 }


### PR DESCRIPTION
This PR takes the points I raised in #16 and implements them along with the original changes to Rust fannkuch redux
notably:
- in fannkuch redux ~20% better performance achieved with:
  - change i32 -> usize conversions to u32 -> usize to get rid of runtime checks, all the nums were strictly increasing so having i32 was redundant
  - simplify `self.t[..current_max_n].copy_from_slice(&self.s[..current_max_n]);` to a simpler loop that better matched other implementations
- don't allocate arguments in the Rust programs, instead keep them in the iterator that the OS gives us 
- Remove printing the results by default in the benchmarks, since some of the benchmarks were in the order of 25µs of computation with 500µs of printing IO time, the printing skewed the numbers too much. You can still enable the printing by having an additional argument if need be for validation, for example.
- Make all the programs compile with -O3 optimization or as fast as they can
- Add a ReleaseSafe and ReleaseFast versions for Zig, to be able to compare them properly

Crucially the decision to print or not to print isn't compile time, because many of the languages are good at removing dead code, so if you don't have any possible effect from the code, the compiler might just delete the calculations entirely from the code. 

One thing that I am not 100% sure on is how to handle the ReleaseSafe and ReleaseFast version for Zig since the benchmarks were clearly not designed to handle multiple different benchmarks with the same language in the same test. I decided to go with just renaming the Compiler to `zig-ReleaseSafe` and `zig-ReleaseFast` and it seemed to work fine. Though I had to remove the check that sees if the compiler names are equal. 

Another thing is that I ran out of colors, so I just defined a RGBA color for yellow to use for fast zig, and it seems to fit fine

I tried to go with adding a label to the benchmarks and using that instead, but the plot creation was too tied to the compiler name for each language, let me know if you think there could be a better solution

here is an example benchmark for the new setup, you shouldnt look at the numbers too much since it was run on a noisy remote machine, but as an illustration of how the colors and the legend look like:
<img width="1116" height="337" alt="vncviewer64-1 16 2_2026-04-27_15-44-04" src="https://github.com/user-attachments/assets/a8fb7e4f-7719-4081-baa9-a9e3a435529c" />

Edit: the above chart is no longer relevant since we removed benchmarking zig in releasefast mode
